### PR TITLE
Adding the Fail Over support for WSO2 GW

### DIFF
--- a/carbon-gw/components/org.wso2.carbon.gateway/src/main/java/org/wso2/carbon/gateway/internal/common/CarbonException.java
+++ b/carbon-gw/components/org.wso2.carbon.gateway/src/main/java/org/wso2/carbon/gateway/internal/common/CarbonException.java
@@ -13,20 +13,26 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-
 package org.wso2.carbon.gateway.internal.common;
 
-
 /**
- * Interface for Message Sender to the BE
+ * Custom exception class for gateway specific exceptions
  */
-public interface TransportSender {
-    /**
-     * Should include the logic for handover messages to BE
-     * @param msg Mediated Request
-     * @param callback Carbon callback created by engine
-     * @return void
-     */
-    public boolean send(CarbonMessage msg, CarbonCallback callback) throws CarbonException;
+public class CarbonException extends Exception {
+
+    public CarbonException() {
+    }
+
+    public CarbonException(String message) {
+        super(message);
+    }
+
+    public CarbonException(Throwable cause) {
+        super(cause);
+    }
+
+    public CarbonException(String message, Throwable cause) {
+        super(message, cause);
+    }
 
 }

--- a/carbon-gw/components/org.wso2.carbon.gateway/src/main/java/org/wso2/carbon/gateway/internal/mediation/camel/CamelMediationEngine.java
+++ b/carbon-gw/components/org.wso2.carbon.gateway/src/main/java/org/wso2/carbon/gateway/internal/mediation/camel/CamelMediationEngine.java
@@ -98,6 +98,8 @@ public class CamelMediationEngine implements CarbonMessageProcessor {
     private CamelMediationConsumer decideConsumer(String uri, String httpMethod) {
 
         String defaultConsumer = "";
+        //Keep the original URI to fallback when there is no REST DSL involved
+        String originalUri = uri;
         uri = uri.concat("?httpMethodRestrict=").concat(httpMethod);
 
         for (String key : consumers.keySet()) {
@@ -106,7 +108,10 @@ public class CamelMediationEngine implements CarbonMessageProcessor {
                 return consumers.get(key);
             }
             if (!key.contains("?httpMethodRestrict=")) {
-                defaultConsumer = key;
+                //Set the default consumer only if key contains the original uri
+                if (key.contains(originalUri)) {
+                    defaultConsumer = key;
+                }
             }
         }
         /* No REST DSL. Return the default consumer.*/

--- a/carbon-gw/components/org.wso2.carbon.gateway/src/main/java/org/wso2/carbon/gateway/internal/transport/sender/NettySender.java
+++ b/carbon-gw/components/org.wso2.carbon.gateway/src/main/java/org/wso2/carbon/gateway/internal/transport/sender/NettySender.java
@@ -23,6 +23,7 @@ import io.netty.handler.codec.http.LastHttpContent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.gateway.internal.common.CarbonCallback;
+import org.wso2.carbon.gateway.internal.common.CarbonException;
 import org.wso2.carbon.gateway.internal.common.CarbonMessage;
 import org.wso2.carbon.gateway.internal.common.TransportSender;
 import org.wso2.carbon.gateway.internal.transport.common.Constants;
@@ -54,7 +55,7 @@ public class NettySender implements TransportSender {
 
 
     @Override
-    public boolean send(CarbonMessage msg, CarbonCallback callback) {
+    public boolean send(CarbonMessage msg, CarbonCallback callback) throws CarbonException {
 
         final HttpRequest httpRequest = Util.createHttpRequest(msg);
 
@@ -86,10 +87,11 @@ public class NettySender implements TransportSender {
 
 
         } catch (Exception e) {
-            log.error("Cannot processed Request to host " + route.toString(), e);
+            //log.error("Cannot processed Request to host " + route.toString(), e);
+            throw new CarbonException("Endpoint failed", e);
         }
 
-        return true;
+        return false;
     }
 
 


### PR DESCRIPTION
With this fix, we can configure failover endpoints with WSO2 GW product. Here is a sample configuration.
<route id="failover">
            <from uri="wso2-gw:/failover"/>
                <loadBalance>
				<failover roundRobin="true"/>
				<to uri="wso2-gw:http://localhost:8280/services/echoproxy"/>        
				<to uri="wso2-gw:http://localhost:8080/services/echo"/>                                 
			</loadBalance>
       </route>  