### PR TITLE
Updating carbon-parent version to 2 with other required changes 

### DIFF
--- a/carbon-gw/components/org.wso2.carbon.gateway/pom.xml
+++ b/carbon-gw/components/org.wso2.carbon.gateway/pom.xml
@@ -196,45 +196,6 @@
                         <deployAtEnd>true</deployAtEnd>
                     </configuration>
                 </plugin>
-
-                <!-- Bundle plugin -->
-                <plugin>
-                    <groupId>org.apache.felix</groupId>
-                    <artifactId>maven-bundle-plugin</artifactId>
-                    <extensions>true</extensions>
-                    <configuration>
-                        <instructions>
-                            <Bundle-Vendor>WSO2 Inc</Bundle-Vendor>
-                            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                            <Bundle-Activator>org.wso2.carbon.gateway.internal.GatewayActivator</Bundle-Activator>
-                            <Private-Package>
-                                org.wso2.carbon.gateway.internal
-                            </Private-Package>
-                            <Export-Package>
-                                !org.wso2.carbon.gateway.internal,
-                                org.wso2.carbon.gateway.*
-                            </Export-Package>
-                            <Import-Package>
-                                org.osgi.framework.*;version="${osgi.framework.import.version.range}",
-                                org.osgi.util.tracker; version="${osgi.service.tracker.import.version.range}",
-                                io.netty.*,
-                                org.wso2.carbon.kernel.transports.*,
-                                org.wso2.carbon.transport.http.netty.*,
-                                org.apache.log4j.*,
-                                org.apache.commons.logging.*,
-                                org.apache.camel.*,
-                                org.apache.commons.pool.*,
-                                com.lmax.disruptor.*,
-                                org.springframework.context.*,
-                                org.w3c.dom.*,
-                                org.xml.sax.*,
-                                javax.xml.*,
-                                org.slf4j.*
-                            </Import-Package>
-                            <_dsannotations>*</_dsannotations>
-                        </instructions>
-                    </configuration>
-                </plugin>
             </plugins>
         </pluginManagement>
 
@@ -268,11 +229,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
                 <version>2.8</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.5.4</version>
             </plugin>
         </plugins>
     </build>
@@ -433,5 +389,31 @@
         </profile>
 
     </profiles>
+
+    <properties>
+        <bundle.activator>org.wso2.carbon.gateway.internal.GatewayActivator</bundle.activator>
+        <private.package>org.wso2.carbon.gateway.internal</private.package>
+        <export.package>
+            !org.wso2.carbon.gateway.internal,
+            org.wso2.carbon.gateway.*
+        </export.package>
+        <import.package>
+            org.osgi.framework.*;version="${osgi.framework.import.version.range}",
+            org.osgi.util.tracker; version="${osgi.service.tracker.import.version.range}",
+            io.netty.*,
+            org.wso2.carbon.kernel.transports.*,
+            org.wso2.carbon.transport.http.netty.*,
+            org.apache.log4j.*,
+            org.apache.commons.logging.*,
+            org.apache.camel.*,
+            org.apache.commons.pool.*,
+            com.lmax.disruptor.*,
+            org.springframework.context.*,
+            org.w3c.dom.*,
+            org.xml.sax.*,
+            javax.xml.*,
+            org.slf4j.*
+        </import.package>
+    </properties>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2</groupId>
         <artifactId>wso2</artifactId>
-        <version>1</version>
+        <version>2</version>
     </parent>
 
     <groupId>org.wso2.carbon.gateway</groupId>


### PR DESCRIPTION
Bundle plugin configuration has been removed and required properties have been added to use the bundle plugin configuration in carbon-parent 2[1].

[1] https://wso2.org/jira/browse/CARBON-15617